### PR TITLE
Update iOS deployment version info to 12.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let packageVersion = "0.109.0"
 let package = Package(
   name: "PayPalCheckout",
   platforms: [
-    .iOS(.v11)
+    .iOS(.v12)
   ],
   products: [
     .library(

--- a/PayPalCheckout.podspec
+++ b/PayPalCheckout.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |spec|
   spec.summary      = "PayPal iOS Native Checkout SDK"
   spec.homepage     = "https://github.com/paypal/paypalcheckout-ios"
   spec.author       = { "PayPal" => "jonathajones@paypal.com" }
-  spec.platform = :ios, "11.0"
+  spec.platform = :ios, "12.0"
   spec.swift_version = "5.0"
 
   spec.source = { :http => "https://github.com/paypal/paypalcheckout-ios/releases/download/#{spec.version}/PayPalCheckout.xcframework.zip" }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@
 [![Carthage version](https://img.shields.io/cocoapods/v/PayPalCheckout?color=brightgreen&label=Carthage)](https://github.com/Carthage/Carthage)
 [![SPM version](https://img.shields.io/cocoapods/v/PayPalCheckout?color=brightgreen&label=SPM)](https://github.com/apple/swift-package-manager)
 
+Welcome to PayPal iOS Checkout SDK! 
+
+This framework allows you to provide a native PayPal checkout experience from within your iOS app.
+
+## Prerequisites
+
+- Deployment target of **iOS 12.0** or higher.
+- Xcode version at least **Xcode 12**.
+- The current language version for the SDK is **Swift 5.4.1**.
+
 ## Docs
 
 To get started, first checkout out our [quickstart integration guide](https://developer.paypal.com/docs/business/native-checkout/ios/)!


### PR DESCRIPTION
We recently dropped support for iOS 11. The SDK minimum deployment target is now `12.0`.

This PR updates all the necessary files accordingly:
- Updated platform version in `Package.swift`
- Updated platform version in `PayPalCheckout.podspec`
- Updated `README.md`, adding a **Prerequisites** section that includes information about the minimum deployment target.