### PR TITLE
Add `CHANGELOG.md` to track release notes

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,10 @@ The `details` object will give you insight into the `Payer`, the array of `Purch
 - Improved accessibility support
 
 ## 0.104.0 (2022-09-01)
-Previously validating an app while submitting to the store would result in a failure, this release fixes that issue.
+- Previously validating an app while submitting to the store would result in a failure, this release fixes that issue.
 
 ## 0.103.0 (2022-08-29)
-Previously, validating an app while submitting to the store would result in a failure relating to a dependency resource bundle and framework path. This release fixes that issue.
+- Previously, validating an app while submitting to the store would result in a failure relating to a dependency resource bundle and framework path. This release fixes that issue.
 
 ## 0.102.0 (2022-09-22)
 - OTP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The `details` object will give you insight into the `Payer`, the array of `Purch
 - Fixes an issue related to dependency resource bundle and framework path during app validation
   while submitting to the store.
 
-## 0.102.0 (2022-09-22)
+## 0.102.0 (2022-08-22)
 - OTP
 - Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+#  Native Checkout iOS SDK Release Notes
+
+## 0.109.0 (2022-10-10)
+- Adding a new interface to get details about an order through Approval.actions. This interface only supports orders created with the orders/v2 API, and integrating with this interface may look something like this:
+```swift
+// Wherever you define the `onApprove` callback
+      ... , 
+      onApprove: { approval in
+        approval.actions.getOrderDetails { details, error in
+          // record the details of your order here
+        }
+      },
+      ...
+```      
+The `details` object will give you insight into the `Payer`, the array of `PurchaseUnits`, and a raw JSON that includes other fields that do not have types added yet.
+- Accessibility Improvements
+- Bug fixes
+
+## 0.108.0 (2022-09-29)
+- Bugfixes and performance improvements
+- Accessibility updates
+- Localization updates
+
+## 0.106.0 (2022-09-06)
+- Full EU support with 3DS support for contingency resolution
+  - For more information on how to enable 3DS support, see the README.md for instructions on installing the `CardinalMobile.xcframework`
+- Bug fixes and improved localizations
+- Improved accessibility support
+
+## 0.104.0 (2022-09-01)
+Previously validating an app while submitting to the store would result in a failure, this release fixes that issue.
+
+## 0.103.0 (2022-08-29)
+Previously, validating an app while submitting to the store would result in a failure relating to a dependency resource bundle and framework path. This release fixes that issue.
+
+## 0.102.0 (2022-09-22)
+- OTP
+- Bug Fixes
+
+## 0.101.0 (2022-07-28)
+- Fixed an issue where users quickly launching and exiting SDK sessions could be given a very poor user experience
+- Resolved some occasionally broken constraints
+- Updated translations
+- Bug fixes and security updates
+
+## 0.100.0 (2022-07-15)
+- Added native support for billing agreement flows
+- Updated localizations
+- Several performance, constraint, and security improvements
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,11 @@ The `details` object will give you insight into the `Payer`, the array of `Purch
 - Improved accessibility support
 
 ## 0.104.0 (2022-09-01)
-- Previously validating an app while submitting to the store would result in a failure, this release fixes that issue.
+- Fixes an issue with app validation when submitting to the store.
 
 ## 0.103.0 (2022-08-29)
-- Previously, validating an app while submitting to the store would result in a failure relating to a dependency resource bundle and framework path. This release fixes that issue.
+- Fixes an issue related to dependency resource bundle and framework path during app validation
+  while submitting to the store.
 
 ## 0.102.0 (2022-09-22)
 - OTP


### PR DESCRIPTION
Previously, release notes were added onto the release tags. 

This PR creates a 'CHANGELOG` markdown file where we store notes on each release, starting from version 0.100.0. It is modeled after the current Braintree changelog.

Relevant JIRA Ticket: https://engineering.paypalcorp.com/jira/browse/DTNATIVEXO-1332