### PR TITLE
[MXO-992] Updating readme with notice for new devs to integrate with BT

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This integration path is only active for existing developers who have previously
 
 # Native Checkout for iOS
 
+<img src="https://img.shields.io/github/v/release/paypal/paypalcheckout-ios?include_prereleases&style=for-the-badge"/>
+
 Welcome to PayPal iOS Checkout SDK! 
 
 This framework allows you to provide a native PayPal checkout experience from within your iOS app.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Native Checkout for iOS
+### Notice
+This integration path is only active for existing developers who have previously integrated the PayPal iOS Checkout SDK. For any new developers seeking the Native Checkout experience, this integration path is considered inactive. Please integrate via [BrainTree iOS SDK](https://github.com/braintree/braintree_ios) or [PayPal iOS SDK](https://github.com/paypal/iOS-SDK/).
 
-[![Platform](https://img.shields.io/cocoapods/p/PayPalCheckout)](https://paypal.github.io/mobile-checkout-docs/ios/reference/)
-[![Pod version](https://img.shields.io/cocoapods/v/PayPalCheckout?color=brightgreen&label=pod)](https://github.com/CocoaPods/CocoaPods)
-[![Carthage version](https://img.shields.io/cocoapods/v/PayPalCheckout?color=brightgreen&label=Carthage)](https://github.com/Carthage/Carthage)
-[![SPM version](https://img.shields.io/cocoapods/v/PayPalCheckout?color=brightgreen&label=SPM)](https://github.com/apple/swift-package-manager)
+---
+
+# Native Checkout for iOS
 
 Welcome to PayPal iOS Checkout SDK! 
 


### PR DESCRIPTION
Adding message to top of our Readme to redirect new devs to integrate with BT https://paypal.atlassian.net/jira/software/c/projects/MXO/issues/MXO-992?filter=allissues

Also updating shields under title to use Github api rather than cocoapod's api, which appears to be busted

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/130789096/236516126-72d96aa4-29cf-40af-8dc6-55cb4d256856.png">
