### PR TITLE
fix link in auto reply script

### DIFF
--- a/.github/workflows/auto-reply-to-raised-issues.yml
+++ b/.github/workflows/auto-reply-to-raised-issues.yml
@@ -30,5 +30,5 @@ jobs:
             
             New merchants can integrate the Native Checkout experience via the Braintree iOS SDK or PayPal iOS SDK.
             For more information please see their respective developer documentation linked below.
-              * [Braintree iOS SDK](https://developer.paypal.com/braintree/docs/guides/paypal/native-checkout/ios/v5)
+              * [Braintree iOS SDK](https://developer.paypal.com/braintree/docs/start/overview)
               * [PayPal iOS SDK](https://developer.paypal.com/beta/advanced-mobile/)


### PR DESCRIPTION
The URL for Braintree docs in the auto-reply script broke since the script was written. This fixes the URL.